### PR TITLE
Eliminar mensaje privado

### DIFF
--- a/common/models/MensajesPrivados.php
+++ b/common/models/MensajesPrivados.php
@@ -17,8 +17,9 @@ use yii\helpers\Html;
  * @property int $receptor_id
  * @property string $asunto
  * @property string $contenido
- * @property bool $visto
  * @property bool $leido
+ * @property bool $del_e
+ * @property bool $del_r
  * @property string $created_at
  * @property string $emisor_name
  * @property string $receptor_name
@@ -49,7 +50,7 @@ class MensajesPrivados extends \yii\db\ActiveRecord
             [['emisor_id', 'receptor_id'], 'default', 'value' => null],
             [['emisor_id', 'receptor_id'], 'integer'],
             [['contenido'], 'string'],
-            [['visto', 'leido'], 'boolean'],
+            [['leido', 'del_e', 'del_r'], 'boolean'],
             [['created_at', 'receptor_name', 'emisor_name'], 'safe'],
             [['asunto'], 'string', 'max' => 255],
             [['emisor_id'], 'exist', 'skipOnError' => true, 'targetClass' => User::className(), 'targetAttribute' => ['emisor_id' => 'id']],
@@ -68,7 +69,6 @@ class MensajesPrivados extends \yii\db\ActiveRecord
             'receptor_id' => 'Receptor ID',
             'asunto' => 'Asunto',
             'contenido' => 'Contenido',
-            'visto' => 'Visto',
             'leido' => 'Leido',
             'created_at' => 'Fecha de envío',
             'emisor_name' => 'Emisor',
@@ -105,8 +105,31 @@ class MensajesPrivados extends \yii\db\ActiveRecord
         return $this->hasOne(User::className(), ['id' => 'receptor_id']);
     }
 
+    /**
+     * Devuelve la url en forma de hipervinculo de este mensaje para verlo en detalle.
+     * @param  string $label Parámetro que indica el nombre del link.
+     * @return string        Hipervínculo.
+     */
     public function getUrl($label)
     {
         return Html::a($label, ['mensajes-privados/view', 'id' => $this->id]);
+    }
+
+    /**
+     * Indica si el usuario conectado es el emisor de este mensaje.
+     * @return bool
+     */
+    public function imEmisor()
+    {
+        return $this->getEmisor()->one()->id == Yii::$app->user->id;
+    }
+
+    /**
+     * Indica si el usuario conectado es el receptor de este mensaje.
+     * @return bool
+     */
+    public function imReceptor()
+    {
+        return $this->getReceptor()->one()->id == Yii::$app->user->id;
     }
 }

--- a/common/models/MensajesPrivadosSearch.php
+++ b/common/models/MensajesPrivadosSearch.php
@@ -20,7 +20,7 @@ class MensajesPrivadosSearch extends MensajesPrivados
         return [
             [['id', 'emisor_id', 'receptor_id'], 'integer'],
             [['asunto', 'contenido', 'created_at', 'receptor_name', 'emisor_name'], 'safe'],
-            [['visto', 'leido'], 'boolean'],
+            [['del_e', 'del_r', 'leido'], 'boolean'],
         ];
     }
 
@@ -69,7 +69,8 @@ class MensajesPrivadosSearch extends MensajesPrivados
             'id' => $this->id,
             'emisor_id' => $this->emisor_id,
             'receptor_id' => $this->receptor_id,
-            'visto' => $this->visto,
+            'del_e' => $this->del_e,
+            'del_r' => $this->del_r,
             'leido' => $this->leido,
             'created_at' => $this->created_at,
         ]);

--- a/db/artchive.sql
+++ b/db/artchive.sql
@@ -105,8 +105,9 @@ CREATE TABLE mensajes_privados (
                                     ON DELETE NO ACTION ON UPDATE CASCADE
     , asunto        varchar(255)    NOT NULL
     , contenido     text            NOT NULL
-    , visto         boolean         NOT NULL DEFAULT FALSE
     , leido         boolean         NOT NULL DEFAULT FALSE
+    , del_e         boolean         NOT NULL DEFAULT FALSE
+    , del_r         boolean         NOT NULL DEFAULT FALSE
     , created_at    timestamp(0)    NOT NULL DEFAULT localtimestamp
 );
 

--- a/frontend/controllers/MensajesPrivadosController.php
+++ b/frontend/controllers/MensajesPrivadosController.php
@@ -142,11 +142,12 @@ class MensajesPrivadosController extends Controller
         if ($mensaje->imEmisor()) {
             $mensaje->del_e = true;
             $mensaje->save();
-        } elseif ($mensaje->imReceptor()) {
+        }
+        if ($mensaje->imReceptor()) {
             $mensaje->del_r = true;
             $mensaje->save();
         }
-        if (($mensaje->del_r && $mensaje->del_e) || ($mensaje->imEmisor() && $mensaje->imReceptor())) {
+        if ($mensaje->del_r && $mensaje->del_e) {
             $mensaje->delete();
         }
 

--- a/frontend/controllers/MensajesPrivadosController.php
+++ b/frontend/controllers/MensajesPrivadosController.php
@@ -61,7 +61,7 @@ class MensajesPrivadosController extends Controller
     {
         $searchModel = new MensajesPrivadosSearch();
         $dataProvider = $searchModel->search(Yii::$app->request->queryParams);
-        $dataProvider->query->where(['receptor_id' => Yii::$app->user->id]);
+        $dataProvider->query->where(['receptor_id' => Yii::$app->user->id, 'del_r' => false]);
 
         return $this->render('index', [
             'searchModel' => $searchModel,
@@ -77,7 +77,7 @@ class MensajesPrivadosController extends Controller
     {
         $searchModel = new MensajesPrivadosSearch();
         $dataProvider = $searchModel->search(Yii::$app->request->queryParams);
-        $dataProvider->query->where(['emisor_id' => Yii::$app->user->id]);
+        $dataProvider->query->where(['emisor_id' => Yii::$app->user->id, 'del_e' => false]);
 
         return $this->render('sent', [
             'searchModel' => $searchModel,
@@ -87,14 +87,19 @@ class MensajesPrivadosController extends Controller
 
     /**
      * Displays a single MensajesPrivados model.
-     * @param integer $id
+     * @param int $id
      * @return mixed
      * @throws NotFoundHttpException if the model cannot be found
      */
     public function actionView($id)
     {
+        $mensaje = $this->findModel($id);
+
+        if (($mensaje->imEmisor() && $mensaje->del_e) || ($mensaje->imReceptor() && $mensaje->del_r)) {
+            return $this->redirect(['index']);
+        }
         return $this->render('view', [
-            'model' => $this->findModel($id),
+            'model' => $mensaje,
         ]);
     }
 
@@ -126,13 +131,24 @@ class MensajesPrivadosController extends Controller
     /**
      * Deletes an existing MensajesPrivados model.
      * If deletion is successful, the browser will be redirected to the 'index' page.
-     * @param integer $id
+     * @param int $id
      * @return mixed
      * @throws NotFoundHttpException if the model cannot be found
      */
     public function actionDelete($id)
     {
-        $this->findModel($id)->delete();
+        $mensaje = $this->findModel($id);
+
+        if ($mensaje->imEmisor()) {
+            $mensaje->del_e = true;
+            $mensaje->save();
+        } elseif ($mensaje->imReceptor()) {
+            $mensaje->del_r = true;
+            $mensaje->save();
+        }
+        if (($mensaje->del_r && $mensaje->del_e) || ($mensaje->imEmisor() && $mensaje->imReceptor())) {
+            $mensaje->delete();
+        }
 
         return $this->redirect(['index']);
     }
@@ -140,7 +156,7 @@ class MensajesPrivadosController extends Controller
     /**
      * Finds the MensajesPrivados model based on its primary key value.
      * If the model is not found, a 404 HTTP exception will be thrown.
-     * @param integer $id
+     * @param int $id
      * @return MensajesPrivados the loaded model
      * @throws NotFoundHttpException if the model cannot be found
      */

--- a/frontend/views/mensajes-privados/index.php
+++ b/frontend/views/mensajes-privados/index.php
@@ -36,6 +36,7 @@ $this->params['breadcrumbs'][] = $this->title;
             //'visto:boolean',
             //'leido:boolean',
             'created_at:datetime',
+            ['class' => 'yii\grid\ActionColumn'],
         ],
     ]); ?>
 </div>

--- a/frontend/views/mensajes-privados/index.php
+++ b/frontend/views/mensajes-privados/index.php
@@ -36,7 +36,7 @@ $this->params['breadcrumbs'][] = $this->title;
             //'visto:boolean',
             //'leido:boolean',
             'created_at:datetime',
-            ['class' => 'yii\grid\ActionColumn'],
+            ['class' => 'yii\grid\ActionColumn',  'template'=> ' {delete}'],
         ],
     ]); ?>
 </div>

--- a/frontend/views/mensajes-privados/sent.php
+++ b/frontend/views/mensajes-privados/sent.php
@@ -37,7 +37,7 @@ $this->params['breadcrumbs'][] = $this->title;
             //'visto:boolean',
             //'leido:boolean',
             'created_at:datetime',
-            ['class' => 'yii\grid\ActionColumn'],
+            ['class' => 'yii\grid\ActionColumn', 'template'=> ' {delete}'],
         ],
     ]); ?>
 </div>

--- a/frontend/views/mensajes-privados/sent.php
+++ b/frontend/views/mensajes-privados/sent.php
@@ -37,6 +37,7 @@ $this->params['breadcrumbs'][] = $this->title;
             //'visto:boolean',
             //'leido:boolean',
             'created_at:datetime',
+            ['class' => 'yii\grid\ActionColumn'],
         ],
     ]); ?>
 </div>


### PR DESCRIPTION
# Eliminar mensaje privado

Un usuario puede eliminar un mensaje privado tanto de su inbox como de su carpeta de enviados, pero dicho mensaje no se eliminará de la base de datos hasta que tanto el emisor como el receptor lo hayan marcado como eliminado.

Closes #59 