### PR TITLE
Pruebas funcionales

### DIFF
--- a/frontend/tests/functional/HomeCest.php
+++ b/frontend/tests/functional/HomeCest.php
@@ -9,6 +9,10 @@ use frontend\tests\FunctionalTester;
  */
 class HomeCest
 {
+    /**
+     * Comprueba el Inicio para invitados.
+     * @param  FunctionalTester $I
+     */
     public function homeParaGuest(FunctionalTester $I)
     {
         $I->amOnRoute('site/index');
@@ -17,6 +21,10 @@ class HomeCest
         $I->see('Comparte tus creaciones', 'li');
     }
 
+    /**
+     * Comprueba el Inicio para conectados.
+     * @param  FunctionalTester $I
+     */
     public function homeParaLogged(FunctionalTester $I)
     {
         $I->amLoggedInAs(1);
@@ -26,6 +34,10 @@ class HomeCest
         $I->see('Mensajes', 'a');
     }
 
+    /**
+     * Comprueba un login fallido desde home (campos no correctos).
+     * @param  FunctionalTester $I
+     */
     public function loginDesdeHomeFallido(FunctionalTester $I)
     {
         $I->amOnRoute('site/index');
@@ -36,10 +48,14 @@ class HomeCest
         $I->see('Nombre de usuario o contraseña incorrecta', '.help-block');
     }
 
+    /**
+     * Comprueba un login exitoso desde home.
+     * @param  FunctionalTester $I
+     */
     public function loginDesdeHomeExitoso(FunctionalTester $I)
     {
         $I->amOnRoute('site/index');
-        $I->fillField(['name' => 'LoginForm[username]'], 'Admin');
+        $I->fillField(['name' => 'LoginForm[username]'], 'Prueba');
         $I->fillField(['name' => 'LoginForm[password]'], '123456');
         $I->click('Conectarte');
         $I->see('Inicio', 'a');
@@ -47,6 +63,10 @@ class HomeCest
         $I->see('Mensajes', 'a');
     }
 
+    /**
+     * Comprueba que funciona correctamente el link a login desde el inicio.
+     * @param  FunctionalTester $I
+     */
     public function irALogin(FunctionalTester $I)
     {
         $I->amOnRoute('site/index');
@@ -54,6 +74,10 @@ class HomeCest
         $I->see('Conectarse', 'h1');
     }
 
+    /**
+     * Comprueba que funciona correctamente el link a signup desde el inicio.
+     * @param  FunctionalTester $I
+     */
     public function irASignUp(FunctionalTester $I)
     {
         $I->amOnRoute('site/index');
@@ -61,6 +85,11 @@ class HomeCest
         $I->see('Registrarse', 'h1');
     }
 
+    /**
+     * Comprueba que funciona correctamente el link para recuperar contraseña
+     * desde el inicio.
+     * @param  FunctionalTester $I
+     */
     public function irARecuperarContraseña(FunctionalTester $I)
     {
         $I->amOnRoute('site/index');

--- a/frontend/tests/functional/HomeCest.php
+++ b/frontend/tests/functional/HomeCest.php
@@ -32,7 +32,7 @@ class HomeCest
         $I->fillField(['name' => 'LoginForm[username]'], 'No existo');
         $I->fillField(['name' => 'LoginForm[password]'], 'No existo');
         $I->click('Conectarte');
-        $I->see('Login', 'h1');
+        $I->see('Conectarse', 'h1');
         $I->see('Nombre de usuario o contraseña incorrecta', '.help-block');
     }
 
@@ -51,14 +51,14 @@ class HomeCest
     {
         $I->amOnRoute('site/index');
         $I->click('Conectarse');
-        $I->see('Login', 'h1');
+        $I->see('Conectarse', 'h1');
     }
 
     public function irASignUp(FunctionalTester $I)
     {
         $I->amOnRoute('site/index');
         $I->click('Registrarse');
-        $I->see('Signup', 'h1');
+        $I->see('Registrarse', 'h1');
     }
 
     public function irARecuperarContraseña(FunctionalTester $I)

--- a/frontend/tests/functional/PersonajesCest.php
+++ b/frontend/tests/functional/PersonajesCest.php
@@ -9,12 +9,20 @@ use frontend\tests\FunctionalTester;
  */
 class PersonajesCest
 {
+    /**
+     * Comprueba que no se puede acceder sin loggear.
+     * @param  FunctionalTester $I
+     */
     public function accederSinLoggear(FunctionalTester $I)
     {
         $I->amOnRoute('personajes/create');
         $I->see('Conectarse', 'h1');
     }
 
+    /**
+     * Comprueba que se puede acceder loggeado.
+     * @param  FunctionalTester $I
+     */
     public function accederLoggeado(FunctionalTester $I)
     {
         $I->amLoggedInAs(1);
@@ -22,6 +30,10 @@ class PersonajesCest
         $I->see('Crear personaje', 'h1');
     }
 
+    /**
+     * Comprueba que no se puede crear un personaje vacío.
+     * @param  FunctionalTester $I
+     */
     public function noVacio(FunctionalTester $I)
     {
         $this->accederLoggeado($I);
@@ -29,6 +41,10 @@ class PersonajesCest
         $I->see('Campo requerido', '.help-block');
     }
 
+    /**
+     * Comprueba que se crea un personaje correctamente.
+     * @param  FunctionalTester $I
+     */
     public function crearPersonaje(FunctionalTester $I)
     {
         $this->accederLoggeado($I);

--- a/frontend/tests/functional/PersonajesCest.php
+++ b/frontend/tests/functional/PersonajesCest.php
@@ -12,7 +12,7 @@ class PersonajesCest
     public function accederSinLoggear(FunctionalTester $I)
     {
         $I->amOnRoute('personajes/create');
-        $I->see('Login', 'h1');
+        $I->see('Conectarse', 'h1');
     }
 
     public function accederLoggeado(FunctionalTester $I)

--- a/frontend/tests/functional/PublicacionesCest.php
+++ b/frontend/tests/functional/PublicacionesCest.php
@@ -12,7 +12,7 @@ class PublicacionesCest
     public function accederSinLoggear(FunctionalTester $I)
     {
         $I->amOnRoute('publicaciones/create');
-        $I->see('Login', 'h1');
+        $I->see('Conectarse', 'h1');
     }
 
     public function accederLoggeado(FunctionalTester $I)

--- a/frontend/tests/functional/PublicacionesCest.php
+++ b/frontend/tests/functional/PublicacionesCest.php
@@ -9,12 +9,21 @@ use frontend\tests\FunctionalTester;
  */
 class PublicacionesCest
 {
+
+    /**
+     * Comprueba que no se puede acceder sin loggear.
+     * @param  FunctionalTester $I
+     */
     public function accederSinLoggear(FunctionalTester $I)
     {
         $I->amOnRoute('publicaciones/create');
         $I->see('Conectarse', 'h1');
     }
 
+    /**
+     * Comprueba que se puede acceder loggeado.
+     * @param  FunctionalTester $I
+     */
     public function accederLoggeado(FunctionalTester $I)
     {
         $I->amLoggedInAs(1);
@@ -22,6 +31,10 @@ class PublicacionesCest
         $I->see('Crear publicación', 'h1');
     }
 
+    /**
+     * Comprueba que no se puede crear una publicación vacía.
+     * @param  FunctionalTester $I
+     */
     public function noVacio(FunctionalTester $I)
     {
         $this->accederLoggeado($I);
@@ -29,6 +42,10 @@ class PublicacionesCest
         $I->see('Campo requerido', '.help-block');
     }
 
+    /**
+     * Comprueba que se crea una publicación correctamente.
+     * @param  FunctionalTester $I
+     */
     public function crearPublicacion(FunctionalTester $I)
     {
         $this->accederLoggeado($I);


### PR DESCRIPTION
# Pruebas funcionales

Como hubo cambios en el CSS y HTML, las pruebas funcionales que se basaban en elementos de html para hacer comprobaciones habían dejado de funcionar.

Esto se ha corregido, y además se ha añadido la documentación faltante a las funciones.